### PR TITLE
fix: add missing heading to Epic Metadata appendix

### DIFF
--- a/appendices/epic-metadata.adoc
+++ b/appendices/epic-metadata.adoc
@@ -1,4 +1,4 @@
-.== Epic metadata
+== Epic metadata
 
 .Guidance and example Epic metadata (with assistance from ChatGPT)
 [.xsmall-table, width=100%, cols="20%,40%,40%"]


### PR DESCRIPTION
Changed `.== Epic metadata` to `== Epic metadata` to create a proper AsciiDoc heading instead of a block title, matching the format used in other appendices like Feature metadata.

Fixes #56

Generated with [Claude Code](https://claude.ai/code)