### PR TITLE
Fix table font sizing in appendices for PDF output

### DIFF
--- a/themes/tminus15-theme.yml
+++ b/themes/tminus15-theme.yml
@@ -40,8 +40,6 @@ role:
   small-list:
     font_size: 8
     line_height: 1.2
-  xsmall-table:
-    font_size: 7
 
 table:
   width: 100%
@@ -51,3 +49,10 @@ table:
     font_style: bold
   body:
     font_size: 10
+  role:
+    xsmall-table:
+      font_size: 7
+      head:
+        font_size: 7
+      body:
+        font_size: 7


### PR DESCRIPTION
Fixes #54

This PR resolves the issue where tables in appendices files were using fonts that were too large, causing them to span too many pages in the PDF output.

## Changes
- Moved `xsmall-table` role definition from general `role:` section to `table: > role:` section in the PDF theme
- Set font size to 7 for both table head and body when using xsmall-table role
- The existing `[.xsmall-table]` syntax in appendices files now works correctly

## Affected Files
5 appendices files using `.xsmall-table` will now have properly sized smaller tables:
- epic-metadata.adoc
- bugs-and-enhancements-metadata.adoc
- feature-metadata.adoc
- task-metadata.adoc
- user-story-metadata.adoc

Generated with [Claude Code](https://claude.ai/code)