### PR TITLE
fix: centre align all images

### DIFF
--- a/chapters/decoding-the-clients-wants-and-needs.adoc
+++ b/chapters/decoding-the-clients-wants-and-needs.adoc
@@ -25,7 +25,7 @@ Get visual: If possible (and applicable) create UX/UI wireframes and walk-throug
 The Product Backlog is our single list of requirements for the business. It is a hierarchical list of Epics, Features, Tasks, Bugs and Improvements.
 
 .Hierarchical structure of our product backlog. NB Risks and issues are held separately outside the hierarchy, but everything else should have a parent/child relationship.
-image::images/product-backlog.png[float=center,align=center]
+image::images/product-backlog.png[align=center]
 
 These items can be prioritized into an order of delivery where the User Stories and above should only be updated with the consent of the Product Owner. The Scrum team will use the currency of Story Points to estimate the workload for items. We’ll cover Story Points later, but in essence they are a unit of prescribed varying sizes (a modified Fibonacci sequence) to help the team estimate work sizes. These estimates also help the Product Owner prioritize work items.
 
@@ -45,7 +45,7 @@ Why do we need this epic? What value are we delivering to the business? These ar
 An Epic can be thought of as an initiative to be undertaken that will initially be a Minimum Viable Product (MVP). An Epic will be delivered through the use of lean start-up principles.
 
 .An economic lean start-up strategy, enabling risk and investment incrementally, whilst allowing for flow, visibility and building with fast, integrated learning cycles as outlined in Principle 4 of SAFe®.
-image::images/lean-startup.png[float=center,align=center]
+image::images/lean-startup.png[align=center]
 
 To see the Epic metadata please see Appendix.
 

--- a/chapters/lets-get-agile.adoc
+++ b/chapters/lets-get-agile.adoc
@@ -9,7 +9,7 @@ Survival today requires speed and adaptability. Your competitors are already mov
 Here's the cold, hard truth: the corporate graveyard is filling up fast. According to Yale professor Richard Foster, S&P500 company lifespans have crashed from 67 years in the 1920s to just 15 years today{empty}footnote:[Creative Destruction Whips through Corporate America, https://engageinnovate.files.wordpress.com/2012/03/creative-destruction-whips-through-corporate-america_final2012.pdf]. That's right – the S&P500 replaces a company every two weeks. If you're comfortable with your current pace, congratulations on your upcoming obsolescence. If you're a hungry newcomer, there's never been a better time to take someone's lunch.
 
 .Creative Destruction Whips through Corporate America
-image::images/average-company-lifespan.png[float=center,align=center,link=https://engageinnovate.files.wordpress.com/2012/03/creative-destruction-whips-through-corporate-america_final2012.pdf]
+image::images/average-company-lifespan.png[align=center,link=https://engageinnovate.files.wordpress.com/2012/03/creative-destruction-whips-through-corporate-america_final2012.pdf]
 
 === Overview of Agile
 
@@ -103,7 +103,7 @@ Getting back to the team again. Agile software development methodology covers a 
 Scrum gives some additional practices to our Agile method ideally suited to software development teams of around 5 to 10 team members utilizing practices such as sprints and daily stand-ups (or daily scrums). It uses iterative sprints of 2 to 4-weeks where a team takes a set of requirements (the sprint backlog taken from a larger product backlog).
 
 .An overview of Scrum
-image::images/scrum.png[float=center,align=center]
+image::images/scrum.png[align=center]
 
 === Kanban vs Scrum
 
@@ -134,7 +134,7 @@ Yes, you still need a high-level roadmap – stakeholders crave it and it helps 
 Smart teams separate their technical release dates from their marketing announcements. Release to production when the feature is solid, then announce it publicly after you've confirmed everything works in the real world. That gap might be days or weeks – but that buffer can save your reputation when surprises pop up (and they will).
 
 .A simple Gantt Chart of the Epic MVP release. Note that the delivery plan doesn't need to get much more detailed than this.
-image::images/gantt-chart.png[float=center,align=center]
+image::images/gantt-chart.png[align=center]
 
 As an aside, in line with SAFe® you may also have an Innovation & Planning (IP) sprint. This sprint _acts as an estimating buffer for meeting PI Objectives and provides dedicated time for innovation, continuing education, PI Planning, and Inspect and Adapt (I&A) events_{empty}footnote:[Innovation & Planning Iteration, https://www.scaledagileframework.com/innovation-and-planning-iteration/]. For more information on IP sprints, see https://www.scaledagileframework.com/innovation-and-planning-iteration/.
 
@@ -143,7 +143,7 @@ As an aside, in line with SAFe® you may also have an Innovation & Planning (IP)
 The Sprint Burndown Chart gives the team a quick graphical representation of the remaining work left in that sprint. It shows us in a view if the team are on track to deliver the promised functionality by the end of the sprint. The ideal burn down diagonal is shown in white and the actual remaining effort (typically shown in hours) in the green bars.
 
 .Representation of the sprint burndown chart.
-image::images/burndown-chart.png[float=center,align=center]
+image::images/burndown-chart.png[align=center]
 
 What does the burndown chart above tell us? Well, it looks like the team had a little bit of a slow start, then picked up speed and got ahead of schedule. They then hit some blockers by the looks of it and started to slip behind schedule, but managed to pick it up with a good effort at the end and completed the sprint. 
 
@@ -190,7 +190,7 @@ Project issues need urgency and ownership. Always assign someone responsible for
 To calculate the total story points that can be carried out in a sprint, we have to appreciate that the engineering time is not the only time required to size a user story! Use the following formula to calculate the total effort for a Story:
 
 .This is a general formula for calculating the total effort involved for a Story.
-image::images/estimating.png[float=center,align=center]
+image::images/estimating.png[align=center]
 
 From the above, in summary the total effort is approximately twice the engineering effort we put in the Story Points. This is useful for calculating the total effort for Features and capacity of Sprints. As a general rule for example, you can see that for every 4 Engineers, on average you're going to need 1 Test Pilot.
 

--- a/chapters/so-what-about-devops.adoc
+++ b/chapters/so-what-about-devops.adoc
@@ -7,7 +7,7 @@ With fear of jumping on a using a portmanteau trend (a shortening a number of wo
 Whilst Agile is intended to close the gap between the customers (business) and the development team, DevOps aims to close the gap between the development team and operations that typically operate in siloes. You can therefore see how utilising both can bring about operational effectiveness of the idea to value for the business. And likewise to Agile, DevOps also requires a cultural change within the enterprise.
 
 .Here we can see a nice summary of where Agile (Scrum) and DevOps operate. Thanks to my son Isaac for his representation of business, developers and IT operators! :-)
-image::images/agile-vs-devops.png[float=center,align=center]
+image::images/agile-vs-devops.png[align=center]
 
 === DevOps Principles
 
@@ -27,7 +27,7 @@ DevOps has the following 7 key principles{empty}footnote:[7 Key Principles for a
 DevOps has the principle of continuous improvement, and as such has a continuous lifecycle as follows:
 
 .The familiar DevOps lifecycle of Prep > Design > Engineer > Test > Operate.
-image::images/infinity-lifecycle-book.png[float=center,align=center]
+image::images/infinity-lifecycle-book.png[align=center]
 
 It should be noted that these individual activities can be carried out within a sprint focused on that activity, as well as during other sprints. The naming convention of these activities has an associated role (see the A-Team). In addition, we have lifecycles for all our work items, whether they are the Epic itself, or its’ Capabilities, Features, Tasks, Improvements or Bugs.
 
@@ -50,7 +50,7 @@ While we’re on the subject of design. Be cautious getting all your screens wir
 With regards to the artefacts that come out of the design stage,  try and keep them nicely coupled to the Features and User Stories. Putting these assets into a tool such as InVision is not only a great way for developers to grab CSS and HTML code from the designs, but it’s also possible to put “notes” on the screens that link to the relevant User Story. For example, you may have a “Delete” button next to a record in the wireframes that has a note to the User Story “I need to be able to delete a record”. Likewise, the User Story can have a link back to the relevant wireframe in InVision.
 
 .Make sure your wireframes are linked to your user stories (for example, if you're using Microsoft DevOps, link directly from the design tool such as InVision to the Story in Microsoft DevOps)
-image::images/designs.png[float=center,align=center]
+image::images/designs.png[align=center]
 
 Remember though, “working software over comprehensive documentation” from our Agile Manifesto, so don’t go to unnecessary levels of documentation that won’t be read anyway – you’ve worked with software developers right?! For example, don’t spend weeks creating mock-ups for each and every page if they are going to be time consuming, but instead create wireframes of the various pages (to save time) and instead create a set of brand guidelines to follow. That way if the design styles need to be changed, we don’t need to retrospectively go back and amend everything. Likewise, our designs and actual delivery won’t get out of sync and cause confusion about what should actual be delivered.
 


### PR DESCRIPTION
Fixes center alignment issues for all 9 images in the T-Minus-15 book by replacing `[float=center,align=center]` with `[align=center]` attributes.

The `float=center` attribute was causing rendering conflicts in AsciiDoc PDF generation. Using just `align=center` is the recommended approach for proper image centering.

Fixes #18

Generated with [Claude Code](https://claude.ai/code)